### PR TITLE
Fixed issue with undefined collection breaking the pagination

### DIFF
--- a/metalsmith-pagination.js
+++ b/metalsmith-pagination.js
@@ -28,6 +28,10 @@ module.exports = function (options) {
     var complete = keys.every(function (name) {
       var collName = name.replace(/collections\./, ''),
           collection = metadata.collections[collName];
+          
+      // If a metalsmith collection does not exist in the passed in
+      // collecttion pagination definitions, skip over it
+      if (!collection) return true;
 
       var pageOptions = extend(DEFAULTS, options[name])
       var toShow = collection

--- a/metalsmith-pagination.js
+++ b/metalsmith-pagination.js
@@ -26,13 +26,13 @@ module.exports = function (options) {
 
     // Iterate over all the paginate names and match with collections.
     var complete = keys.every(function (name) {
-      var collName = name.replace(/collections\./, ''),
-          collection = metadata.collections[collName];
-          
+      var collName = name.replace(/collections\./, '');
+      
       // If a metalsmith collection does not exist in the passed in
       // collecttion pagination definitions, skip over it
-      if (!collection) return true;
-
+      if (!metadata.collections.hasOwnProperty(collName)) return true;
+          
+      var collection = metadata.collections[collName];
       var pageOptions = extend(DEFAULTS, options[name])
       var toShow = collection
       var groupBy = toFn(pageOptions.groupBy || groupByPagination)


### PR DESCRIPTION
Passing in a collection key that does not exist currently causes this plugin to halt. This fix allow the plugin to continue and skip over the collection if it does not exist.

Try passing a pagination definition in (with and without this PR) to see the effect:

``` javascript
'collections.nada': {
    perPage: [6, 12],
    layout: 'paginated-articles.hbt',
    path: 'partials/nada/:num/index.html'
  }
```
