### PR TITLE
THOR-1176 Update pagination to allow for full-page paginating

### DIFF
--- a/metalsmith-pagination.js
+++ b/metalsmith-pagination.js
@@ -27,11 +27,11 @@ module.exports = function (options) {
     // Iterate over all the paginate names and match with collections.
     var complete = keys.every(function (name) {
       var collName = name.replace(/collections\./, '');
-      
+
       // If a metalsmith collection does not exist in the passed in
       // collecttion pagination definitions, skip over it
       if (!metadata.collections.hasOwnProperty(collName)) return true;
-          
+
       var collection = metadata.collections[collName];
       var pageOptions = extend(DEFAULTS, options[name])
       var toShow = collection
@@ -95,6 +95,7 @@ module.exports = function (options) {
 
           // Generate the page data.
           var page = extend(pageOptions.pageMetadata, {
+            category: pageOptions.category,
             template: pageOptions.template,
             layout: pageOptions.layout,
             contents: pageOptions.pageContents,
@@ -168,12 +169,12 @@ function interpolate (path, data) {
  * @return {number}
  */
 function groupByPagination (file, index, options) {
-  // If options.perPage is a single value, all pages have the same 
+  // If options.perPage is a single value, all pages have the same
   // number of results per page
   if (!Array.isArray(options.perPage)) {
     return Math.ceil((index + 1) / options.perPage)
-    
-  // Otherwise options.perPage[0] is number of results for 1st page, 
+
+  // Otherwise options.perPage[0] is number of results for 1st page,
   // options.perPage[1] is number of results for all other pages
   } else {
     return (index < options.perPage[0] ? 1 : (Math.ceil((index - options.perPage[0] + 1) / options.perPage[1]))+1);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theladbiblegroup/metalsmith-pagination",
-  "version": "1.4.3-0",
+  "version": "1.4.3",
   "description": "A Metalsmith plugin for paginating arrays and collections.",
   "main": "metalsmith-pagination.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@theladbiblegroup/metalsmith-pagination",
-  "version": "1.4.2",
+  "version": "1.4.3-0",
   "description": "A Metalsmith plugin for paginating arrays and collections.",
   "main": "metalsmith-pagination.js",
   "scripts": {


### PR DESCRIPTION
Update the plugin to pass the category through - this means that if needed, we can build full-page 'pagination' for categories etc. 